### PR TITLE
Adding OpenWHO FAQ Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,21 @@ These instructions will get you a copy of the project up and running on your loc
     ```
     This may take a while...
 1. Train the models, so the chatbot knows how to behave.
+
+    For OpenSAP: 
     ```sh
     docker-compose run rasa-core python -m rasa_core.train -d data/opensap_faq/domain.yml -s data/opensap_faq/stories.md -o model/opensap_faq --epochs 200
     ```
     ```sh
     docker-compose run rasa-nlu python -m rasa_nlu.train -c config.yml -d data/opensap_faq -o projects --project opensap_faq
+    ```
+
+    For OpenWHO:
+    ```sh
+    docker-compose run rasa-core python -m rasa_core.train -d data/openwho_faq/domain.yml -s data/openwho_faq/stories.md -o model/openwho_faq --epochs 200
+    ```
+    ```sh
+    docker-compose run rasa-nlu python -m rasa_nlu.train -c config.yml -d data/openwho_faq -o projects --project openwho_faq
     ```
 1. Start the containers.
     ```sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,11 +7,11 @@ services:
       context: ./rasa-core
       dockerfile: Dockerfile
     command: ["python", "run_server.py"]
-    # command: python -m rasa_core.server --debug -d model/opensap_faq
+    # command: python -m rasa_core.server --debug -d model/openwho_faq
     environment:
-      - RASA_CORE_MODEL_PATH=./model/opensap_faq
-      - RASA_CORE_QUESTIONS_PATH=./data/opensap_faq/intent_questions.json
-      - RASA_NLU_PROJECT_NAME=opensap_faq
+      - RASA_CORE_MODEL_PATH=./model/openwho_faq
+      - RASA_CORE_QUESTIONS_PATH=./data/openwho_faq/intent_questions.json
+      - RASA_NLU_PROJECT_NAME=openwho_faq
       - RASA_NLU_MODEL_NAME=
       - RASA_NLU_SERVER_ADDRESS=http://rasa-nlu:5000
       - RASA_NLU_SERVER_TOKEN=

--- a/rasa-core/data/openwho_faq/domain.yml
+++ b/rasa-core/data/openwho_faq/domain.yml
@@ -1,0 +1,92 @@
+intents:
+  - conversation_greet
+  - conversation_goodbye
+  - conversation_thank_you
+  - conversation_confirm
+  - conversation_cancel
+  - payment_question
+  - timelimit_question
+  - confirmation_of_participation_question
+  - confirmation_of_participation_download_question
+  - account_creation_question
+  - confirmation_email_problem
+  - course_enrollment_question
+  - mobile_device_question
+  - password_reset_question
+  - technical_difficulties_question
+  - who_credentials_usage_question
+
+actions:
+  - utter_conversation_greet
+  - utter_conversation_goodbye
+  - utter_conversation_offer_help
+  - utter_conversation_youre_welcome
+  - utter_conversation_canceled
+  - utter_payment_question
+  - utter_timelimit_question
+  - utter_confirmation_of_participation_question
+  - utter_confirmation_of_participation_download_question
+  - utter_account_creation_question
+  - utter_confirmation_email_problem
+  - utter_course_enrollment_question
+  - utter_mobile_device_question
+  - utter_password_reset_question
+  - utter_technical_difficulties_question
+  - utter_who_credentials_usage_question
+
+templates:
+utter_conversation_greet:
+    - text: "Hello."
+    - text: "Hi!"
+    - text: "Hey!"
+
+  utter_conversation_goodbye:
+    - text: "Good bye."
+    - text: "Have a nice day."
+    - text: "Bye!"
+
+  utter_conversation_offer_help:
+    - text: "How can I help you?"
+    - text: "What can I do for you?"
+
+  utter_conversation_youre_welcome:
+    - text: "You're welcome."
+    - text: "It's always nice to be of help."
+
+  utter_conversation_canceled:
+    - text: "Okay, I will not do that."
+    - text: "Alright, I won't."
+    
+  utter_payment_question:
+    - text: "No, all OpenWHO courses are free and open to anyone wishing to register."
+  
+  utter_timelimit_question:
+    - text: "No, OpenWHO courses are self-paced. You can take as much time as you need to complete a course."
+  
+  utter_confirmation_of_participation_question:
+    - text: "Some OpenWHO courses offer confirmation of participation, but some don't. We will soon add a confirmation of participation for more existing courses, and you will be able to download it without having to take the course again. Stay tuned."
+
+  utter_confirmation_of_participation_download_question:
+    - text: "Once you have successfully completed a course, you can download the confirmation of participation in progress section, located on the top course navigation. Link to download the confirmation of participation is at the bottom of the progress page."
+
+  utter_account_creation_question:
+    - text: "Anyone can create a profile on OpenWHO. "Log in" button is located on the top navigation bar, on the far right. Click on it and choose "Create new account." It's going to open a new page where you will need to fill out your name, last name, email address and the password. Once it's done, click on "Register for OpenWHO." You will receive a link in your email to confirm your account."
+
+  utter_confirmation_email_problem:
+    - text: "If you have not received a confirmation email, please check your spam folder and move the email to your primary mailbox. This is of particular concern to Gmail and Yahoo users. If you have checked all your folders, but the confirmation email in not there, please contact us through the help desk and request the confirmation email to be resent."
+
+  utter_course_enrollment_question:
+    - text: "Once you have created a profile and are logged in, choose the course you want to take. To learn more about the course, click on "Show course details." To enroll, click on "Enroll me for this course." Once enrolled, you can start the course immediately or come back later."
+
+  utter_mobile_device_question:
+    - text: "All OpenWHO content is compatible with mobile. OpenWHO apps are available for IOS and Android devices."
+
+  utter_password_reset_question:
+    - text: "Don't worry. Go to the "Log in" page. Click on the link "Forgot your password?". A new page will open asking for your email address. Type it in. Click on "Request password reset.". Your new password has been sent to your email."
+
+  utter_technical_difficulties_question:
+    - text: "In case of technical difficulties, please send us a message through the help desk explaining the problem. We will get back to you as soon as possible."
+
+  utter_who_credentials_usage_question:
+    - text: "Yes, you can use your WHO credentials to access OpenWHO courses. However, if you have issues logging in using your WIMS account, please create an account with your personal email address."
+    

--- a/rasa-core/data/openwho_faq/domain.yml
+++ b/rasa-core/data/openwho_faq/domain.yml
@@ -35,7 +35,7 @@ actions:
   - utter_who_credentials_usage_question
 
 templates:
-utter_conversation_greet:
+  utter_conversation_greet:
     - text: "Hello."
     - text: "Hi!"
     - text: "Hey!"
@@ -70,19 +70,19 @@ utter_conversation_greet:
     - text: "Once you have successfully completed a course, you can download the confirmation of participation in progress section, located on the top course navigation. Link to download the confirmation of participation is at the bottom of the progress page."
 
   utter_account_creation_question:
-    - text: "Anyone can create a profile on OpenWHO. "Log in" button is located on the top navigation bar, on the far right. Click on it and choose "Create new account." It's going to open a new page where you will need to fill out your name, last name, email address and the password. Once it's done, click on "Register for OpenWHO." You will receive a link in your email to confirm your account."
+    - text: "Anyone can create a profile on OpenWHO. 'Log in' button is located on the top navigation bar, on the far right. Click on it and choose 'Create new account.' It's going to open a new page where you will need to fill out your name, last name, email address and the password. Once it's done, click on 'Register for OpenWHO.'' You will receive a link in your email to confirm your account."
 
   utter_confirmation_email_problem:
     - text: "If you have not received a confirmation email, please check your spam folder and move the email to your primary mailbox. This is of particular concern to Gmail and Yahoo users. If you have checked all your folders, but the confirmation email in not there, please contact us through the help desk and request the confirmation email to be resent."
 
   utter_course_enrollment_question:
-    - text: "Once you have created a profile and are logged in, choose the course you want to take. To learn more about the course, click on "Show course details." To enroll, click on "Enroll me for this course." Once enrolled, you can start the course immediately or come back later."
+    - text: "Once you have created a profile and are logged in, choose the course you want to take. To learn more about the course, click on 'Show course details.' To enroll, click on 'Enroll me for this course.' Once enrolled, you can start the course immediately or come back later."
 
   utter_mobile_device_question:
     - text: "All OpenWHO content is compatible with mobile. OpenWHO apps are available for IOS and Android devices."
 
   utter_password_reset_question:
-    - text: "Don't worry. Go to the "Log in" page. Click on the link "Forgot your password?". A new page will open asking for your email address. Type it in. Click on "Request password reset.". Your new password has been sent to your email."
+    - text: "Don't worry. Go to the 'Log in' page. Click on the link 'Forgot your password?'. A new page will open asking for your email address. Type it in. Click on 'Request password reset.' Your new password has been sent to your email."
 
   utter_technical_difficulties_question:
     - text: "In case of technical difficulties, please send us a message through the help desk explaining the problem. We will get back to you as soon as possible."

--- a/rasa-core/data/openwho_faq/intent_questions.json
+++ b/rasa-core/data/openwho_faq/intent_questions.json
@@ -1,0 +1,13 @@
+{
+    "payment_question": "Do you want to know if OpenWHO costs you money?",
+    "timelimit_question": "Do you want to know if the courses have timelimits?",
+    "confirmation_of_participation_question": "Do you want to know if we offer a confirmation of participation for our courses?",
+    "confirmation_of_participation_download_question": "Do you want to know where you can download your confirmation of participation?",
+    "account_creation_question": "Do you want to know where you can create an account?",
+    "confirmation_email_problem": "Do you have difficulties receiving the confirmation email?",
+    "course_enrollment_question": "Do you want to know how you can enroll in our courses?",
+    "mobile_device_question": "Do you want to know about our Apps and mobile content?",
+    "password_reset_question": "Do you need help resetting or retrieving your password?",
+    "technical_difficulties_question": "Do you have technical difficulties?",
+    "who_credentials_usage_question": "Do you want to know if you can use your WHO credentials to log in?"
+}

--- a/rasa-core/data/openwho_faq/stories.md
+++ b/rasa-core/data/openwho_faq/stories.md
@@ -1,0 +1,56 @@
+## welcome
+* conversation_greet
+  - utter_conversation_greet
+  - utter_conversation_offer_help
+
+## goodbye
+* conversation_goodbye
+  - utter_conversation_goodbye
+
+## thanks
+* conversation_thank_you
+  - utter_conversation_youre_welcome
+
+## payment question answer
+* payment_question
+    - utter_payment_question
+
+## timelimit question answer
+* timelimit_question
+    - utter_timelimit_question
+
+## confirmation of participation question answer
+* confirmation_of_participation_question
+    - utter_confirmation_of_participation_question
+
+## confirmation of participation dowload question answer
+* confirmation_of_participation_download_question
+    - utter_confirmation_of_participation_download_question
+
+## account creation question answer
+* account_creation_question
+    - utter_account_creation_question
+
+## confirmation email problem answer
+* confirmation_email_problem
+    - utter_confirmation_email_problem
+
+## course enrollment question answer
+* course_enrollment_question
+    - utter_course_enrollment_question
+
+## mobile device question answer
+* mobile_device_question
+    - utter_mobile_device_question
+
+## password reset question answer
+* password_reset_question
+    - utter_password_reset_question
+
+## technical difficulties question answer
+* technical_difficulties_question
+    - utter_technical_difficulties_question
+
+## who credentials usage question answer
+* who_credentials_usage_question
+    - utter_who_credentials_usage_question

--- a/rasa-nlu/data/openwho_faq/conversation.md
+++ b/rasa-nlu/data/openwho_faq/conversation.md
@@ -1,0 +1,65 @@
+## intent:conversation_greet
+- hey
+- hello
+- hi
+- hello there
+- good morning
+- good evening
+- moin
+- hey there
+- let's go
+- hey dude
+- goodmorning
+- goodevening
+- good afternoon
+
+## intent:conversation_goodbye
+- cu
+- good by
+- cee you later
+- good night
+- good afternoon
+- bye
+- goodbye
+- have a nice day
+- see you around
+- bye bye
+- see you later
+
+## intent:conversation_thank_you
+- thank you
+- thanks
+- ta
+- thanks a lot
+- okay, thank you
+- okay, thanks
+- thats very helpful
+- thank you you're so helpful
+- thank you very much
+- thank you I really appreciate your help
+- thank you for helping me
+- you're the best
+
+## intent:conversation_confirm
+- yep
+- yup
+- yes
+- yeah
+- yes, please
+- exactly
+- do it
+- okay
+- ok
+
+## intent:conversation_cancel
+- no
+- noooo
+- forget it
+- no don't do it
+- not now
+- that is not what i wanted
+- stop
+- nope
+- nah
+- don't do it
+- please dont

--- a/rasa-nlu/data/openwho_faq/general.md
+++ b/rasa-nlu/data/openwho_faq/general.md
@@ -1,0 +1,77 @@
+## intent:payment_question
+- do I have to pay for openwho courses? 
+- how much does openwho cost
+- what is the price of openwho
+- do the courses cost money?
+- is openwho free? 
+
+## intent:timelimit_question
+- do these courses have any time limit? 
+- how long can I do the courses? 
+- when should I finish my courses
+- do the courses end sometime? 
+
+## intent:confirmation_of_participation_question
+- do all courses offer confirmation of participation? 
+- do I get a participation certificate? 
+- can I get a certificate of participation
+- please give me a confirmation of participation
+- I need a certificate
+- I want a confirmation
+
+## intent:account_creation_question
+- how do I create a profile? 
+- how do I create an account
+- where do I register 
+- I need a new account
+- how can I start using openwho?
+
+## intent:confirmation_email_problem
+- what to do in case I did not receive a confirmation email? 
+- I did not recieve the confirmation email
+- I did not get the confirmation email
+- I do not find the confirmation mail 
+- I can not see the email for confirmation
+- where do I find the confirmation mail?
+
+## intent:course_enrollment_question
+- how do I enroll in a course?
+- how to join a course
+- where can I join a course?
+- how to participate in a course?
+- where to enroll in a course
+
+## intent:mobile_device_question
+- will the platform work on mobile devices?
+- can I use openwho on my phone
+- can I use openwho on android
+- can I use openwho on IOS?
+- is there an openwho app? 
+- how to use openwho on my mobile
+
+## intent:confirmation_of_participation_download_question
+- how can I download a confirmation of participation?
+- where do I get a certificate of participation
+- where can I download a confirmation of participation? 
+
+## intent:password_reset_question
+- I forgot my password, what can I do? 
+- I lost my password
+- I forgot my password
+- How can I retrieve my password
+- I need to reset my password
+- where can I reset my password
+- where can I retrieve my password
+
+## intent:technical_difficulties_question
+- I am experiencing technical difficulties, what can I do? 
+- I have technical problems
+- where can I get help with a technical problem? 
+- I have technical difficulties
+- I need help with a technical problem
+
+## intent:who_credentials_usage_question
+- can I use my who credentials to log in the platform? 
+- can I use my who account for openwho? 
+- do I need a new account for openwho or can I use my who account? 
+- can I use my who credentials


### PR DESCRIPTION
Added openwho_faq folder in rasa-core/data with domain.yml and stories.md

Added openwho_faq folder in rasa-nlu/data along with conversation.md and general.md 

Added the potential training-commands for the openWHO in the Readme.md

However this exception is thrown when trying to train the rasa-core: 
ruamel.yaml.parser.ParserError: while parsing a block mapping
  in "data/openwho_faq/domain.yml", line 1, column 1
expected <block end>, but found '<block mapping start>'
  in "data/openwho_faq/domain.yml", line 43, column 3