### PR TITLE
Color schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ To improve the NLU the input of the user is saved as an example for the alternat
 
 ## Color Schemes
 In order to apply a fitting color scheme for either OpenSAP or OpenWHO, a variable in the "App.js" file has to be changed. 
-You can find the file in the directory [`chat-ui/src/App.css`](chat-ui/src/App.css). Then change the variable "colorScheme", in the "getColorScheme"-function, to either "orangeGrey" (for OpenSAP) or "greenGrey" (for OpenWHO). 
+You can find the file in the directory [`chat-ui/src/App.js`](chat-ui/src/App.js). Then change the variable "colorScheme", in the "getColorScheme"-function, to either "orangeGrey" (for OpenSAP) or "greenGrey" (for OpenWHO). 
 
 
 ## Future Work

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ During our university masters seminar we build a chat bot prototype to enhance t
 - [Training Models](#training-models)
 - [Actions](#actions)
 - [User Feedback](#user-feedback)
+- [Color Schemes](#color-schemes)
 - [Future Work](#future-work)
 
 
@@ -168,6 +169,11 @@ To offer this to the user, you need to define these questions for each intent in
 When the user chooses one of the alternatives, the endpoint `http://localhost:5005/conversations/<sender_id>/tracker/reset_intent?intent=<alt_intent>` is called with the respective intent name. This resets the tracker for the current conversation to the last user input and executes the actions for the new intent.
 
 To improve the NLU the input of the user is saved as an example for the alternative intent in `rasa_nlu/data/<project_name>/user_input`. These markdown files are used in the next training for the model of the given project.
+
+
+## Color Schemes
+In order to apply a fitting color scheme for either OpenSAP or OpenWHO, a variable in the "App.js" file has to be changed. 
+You can find the file in the directory [`chat-ui/src/App.css`](chat-ui/src/App.css). Then change the variable "colorScheme", in the "getColorScheme"-function, to either "orangeGrey" (for OpenSAP) or "greenGrey" (for OpenWHO). 
 
 
 ## Future Work

--- a/chat-ui/src/App.css
+++ b/chat-ui/src/App.css
@@ -134,12 +134,12 @@
 }
 
 .Question-Box:focus.greenGrey {
-  border-color: rgb(119, 180, 35);
+  border: 1px solid rgb(119, 180, 35);
   box-shadow:  0 0 5px rgb(119, 180, 35);
 }
 
 .Question-Box:focus.orangeGrey {
-  border-color: #d4652d;
+  border: 1px solid #d4652d;
   box-shadow:  0 0 5px #d4652d;
 }
 

--- a/chat-ui/src/App.css
+++ b/chat-ui/src/App.css
@@ -26,7 +26,7 @@
   margin-bottom: 5px;
 }
 
-.answer::before.greenGrey, .alternative::before.greenGrey {
+.answer.greenGrey::before, .alternative::before {
   z-index: 1;
   display: inline-block;
   position: absolute;
@@ -40,7 +40,7 @@
   content: ' ';
 }
 
-.answer::before.orangeGrey, .alternative::before.orangeGrey {
+.answer.orangeGrey::before, .alternative::before {
   z-index: 1;
   display: inline-block;
   position: absolute;
@@ -105,7 +105,7 @@
   color: white;
 }
 
-.question::after.greenGrey {  
+.question.greenGrey::after {  
   z-index: 1;
   display: inline-block;
   position: absolute;
@@ -119,7 +119,7 @@
   content: ' '
 }
 
-.question::after.orangeGrey {  
+.question.orangeGrey::after {  
   z-index: 1;
   display: inline-block;
   position: absolute;

--- a/chat-ui/src/App.css
+++ b/chat-ui/src/App.css
@@ -8,14 +8,9 @@
   margin-top: 8px;
 }
 
-.btn-send {
-  padding: 0px;
-  width: 64px;
-}
-
 #conversation {
   margin-top: 16px;
-  border: 1px solid rgb(54, 54, 54);
+  border: 1px solid #5a6065;
   padding: 8px 16px;
   width: 100%;
   height: 60vh;
@@ -31,7 +26,7 @@
   margin-bottom: 5px;
 }
 
-.answer::before, .alternative::before {
+.answer::before.greenGrey, .alternative::before.greenGrey {
   z-index: 1;
   display: inline-block;
   position: absolute;
@@ -39,18 +34,41 @@
   top: 0px;
   width: 0;
   height: 0;
-  border-top: 16px solid #000000;
+  border-top: 16px solid rgb(119, 180, 35);
   border-left: 10px solid transparent;
   border-right: 10px solid transparent;
   content: ' ';
 }
 
-.answer {  
+.answer::before.orangeGrey, .alternative::before.orangeGrey {
+  z-index: 1;
+  display: inline-block;
+  position: absolute;
+  left: -10px;
+  top: 0px;
+  width: 0;
+  height: 0;
+  border-top: 16px solid #d4652d;
+  border-left: 10px solid transparent;
+  border-right: 10px solid transparent;
+  content: ' ';
+}
+
+.answer.greenGrey {  
+  background-color: rgb(119, 180, 35);
+  color: white;
+}
+
+.answer.orangeGrey {  
   background-color: #d4652d;
   color: white;
 }
 
-.answer::before {  
+.answer::before.greenGrey{  
+  border-top-color: rgb(119, 180, 35);
+}
+
+.answer::before.orangeGrey{  
   border-top-color: #d4652d;
 }
 
@@ -75,13 +93,33 @@
   border-top-color: #dbdbdb;
 }
 
-.question {
+.question.greenGrey {
+  margin-left: 40%;
+  background-color: #5a6065;
+  color: white;
+}
+
+.question.orangeGrey {
   margin-left: 40%;
   background-color: #363636;
   color: white;
 }
 
-.question::after {  
+.question::after.greenGrey {  
+  z-index: 1;
+  display: inline-block;
+  position: absolute;
+  right: -10px;
+  top: 0px;
+  width: 0;
+  height: 0;
+  border-top: 16px solid #5a6065;
+  border-left: 10px solid transparent;
+  border-right: 10px solid transparent;
+  content: ' '
+}
+
+.question::after.orangeGrey {  
   z-index: 1;
   display: inline-block;
   position: absolute;
@@ -93,4 +131,25 @@
   border-left: 10px solid transparent;
   border-right: 10px solid transparent;
   content: ' '
+}
+
+.Question-Box:focus.greenGrey {
+  border-color: rgb(119, 180, 35);
+  box-shadow:  0 0 5px rgb(119, 180, 35);
+}
+
+.Question-Box:focus.orangeGrey {
+  border-color: #d4652d;
+  box-shadow:  0 0 5px #d4652d;
+}
+
+.btn-send.greenGrey {
+  padding: 0px;
+  width: 64px;
+  background-color: #5a6065;
+}
+.btn-send.orangeGrey {
+  padding: 0px;
+  width: 64px;
+  background-color: #363636;
 }

--- a/chat-ui/src/App.js
+++ b/chat-ui/src/App.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import logo from './logo.svg';
 import './App.css';
-import { Button, FormGroup, FormControl } from 'react-bootstrap';
 import axios from 'axios'
 
 class App extends Component {
@@ -21,13 +20,19 @@ class App extends Component {
     this.currText = '';
   }
 
+  getColorScheme() {
+    //colorSchemes can be changed here and include "greenGrey" and "orangeGrey"
+    var colorScheme = "greenGrey";
+    return colorScheme.toString();
+  }
+
   handleClick() {
     if(!this.altclicked) {
       var list = document.getElementById('curr-conv');
       if (list) {
         list.parentNode.removeChild(list);
         let newElem = document.createElement('div');
-        newElem.classList.add('message-box', 'answer');
+        newElem.classList.add('message-box', 'answer', this.getColorScheme());
         newElem.innerHTML = this.currText;
         document.getElementById('conversation').appendChild(newElem);
       }
@@ -50,14 +55,14 @@ class App extends Component {
       })
       .finally(() => {
         this.setState({ waitingForResponse: false });
-        document.getElementsByClassName('Question-Box')[0].focus();
+        document.getElementsByClassName('Question-Box ' + this.getColorScheme())[0].focus();
       });
   }
 
   addAnswerToConversation(answers) {
     answers.forEach((answer) => {
         let newElem = document.createElement('div');
-        newElem.classList.add('message-box', 'answer');
+        newElem.classList.add('message-box', 'answer', this.getColorScheme());
         newElem.innerHTML = answer.text.trim();
         document.getElementById('conversation').appendChild(newElem);
         this.currText = answer.text.trim();
@@ -112,7 +117,7 @@ class App extends Component {
   addQuestionToConversation(question) {
     this.removeIntentsFromChat();
     let newElem = document.createElement('div');
-    newElem.classList.add('message-box', 'question');
+    newElem.classList.add('message-box', 'question', this.getColorScheme());
     newElem.innerHTML = question.trim();
     document.getElementById('conversation').appendChild(newElem);
   }
@@ -126,7 +131,7 @@ class App extends Component {
       <div className="chat-ui">
         <div id="conversation"></div>
         <form>
-          <FormGroup
+          <form
             className="form-group"
             controlId="formBasicText"
             onKeyPress={event => {
@@ -136,17 +141,17 @@ class App extends Component {
               }
             }}
           >
-            <FormControl
+            <input
               type="text"
               value={this.state.value}
               placeholder="Write message"
-              className="Question-Box"
+              className={"Question-Box " + this.getColorScheme()}
               onChange={this.handleChange}
               autoComplete="off"
               disabled={this.state.waitingForResponse}
             />
-            <Button onClick={this.handleClick} bsStyle="primary" className="btn-send"><img src="/assets/send.png" /></Button>
-          </FormGroup>
+            <button type="button" onClick={this.handleClick} className={'btn-send ' + this.getColorScheme()}> <img src="/assets/send.png"/> </button>
+          </form>
         </form>
       </div>
     );


### PR DESCRIPTION
Readme.md: 
New headline for color schemes and a short explanation on how & where to switch between the two existing color schemes "greenGrey" & "orangeGrey". So far no explanation on how to implement your own color scheme. Necessary? 

App.js: 
Replaced all React-Bootstrap Elements in the render() with normal html-elements. 
All of these elements, as well as question- and answer-elements get the current value of the colorScheme-variable as an additional classname. 
However alternative-elements are always the same neutral-grey at the moment. 

App.css: 
Button, input-form, answers and questions all have two seperate styles. One for each colorScheme. 

Problems: 

- [FIXED] The speech-bubble styling of the answers and questions is not working at the moment. 
- When the chatbot is processing a question the input-form turns to a light green. Only noticable for the first message (when the chatbot takes a few seconds to fire up)
- [FIXED] The current border on the active input form looks weird. But if not used, there always is an orange border. 